### PR TITLE
Farting around

### DIFF
--- a/lib/prometheus/client/counter.rb
+++ b/lib/prometheus/client/counter.rb
@@ -10,11 +10,11 @@ module Prometheus
         :counter
       end
 
-      def increment(by: 1, labels: {})
+      def increment(by: 1, labels: {}, exemplar: nil)
         raise ArgumentError, 'increment must be a non-negative number' if by < 0
 
         label_set = label_set_for(labels)
-        @store.increment(labels: label_set, by: by)
+        @store.increment(labels: label_set, by: by, exemplar: exemplar)
       end
     end
   end

--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -99,13 +99,13 @@ module Prometheus
             end
           end
 
-          def set(labels:, val:)
+          def set(labels:, val:, exemplar: nil)
             in_process_sync do
               internal_store.write_value(store_key(labels), val.to_f)
             end
           end
 
-          def increment(labels:, by: 1)
+          def increment(labels:, by: 1, exemplar: nil)
             if @values_aggregation_mode == DirectFileStore::MOST_RECENT
               raise InvalidStoreSettingsError,
                     "The :most_recent aggregation does not support the use of increment"\
@@ -118,13 +118,13 @@ module Prometheus
             end
           end
 
-          def get(labels:)
+          def get(labels:, with_exemplars: false)
             in_process_sync do
               internal_store.read_value(store_key(labels))
             end
           end
 
-          def all_values
+          def all_values(with_exemplars: false)
             stores_data = Hash.new{ |hash, key| hash[key] = [] }
 
             # There's no need to call `synchronize` here. We're opening a second handle to

--- a/lib/prometheus/client/data_stores/single_threaded.rb
+++ b/lib/prometheus/client/data_stores/single_threaded.rb
@@ -29,7 +29,7 @@ module Prometheus
 
         class MetricStore
           def initialize
-            @internal_store = Hash.new { |hash, key| hash[key] = ValueWithExemplars.new }
+            @internal_store = Hash.new { |hash, key| hash[key] = Prometheus::Client::ValueWithExemplars.new }
           end
 
           def synchronize

--- a/lib/prometheus/client/data_stores/single_threaded.rb
+++ b/lib/prometheus/client/data_stores/single_threaded.rb
@@ -1,3 +1,7 @@
+require "prometheus/client/value_with_exemplars"
+require "prometheus/client/exemplar_collection"
+require "prometheus/client/exemplar"
+
 module Prometheus
   module Client
     module DataStores
@@ -25,27 +29,41 @@ module Prometheus
 
         class MetricStore
           def initialize
-            @internal_store = Hash.new { |hash, key| hash[key] = 0.0 }
+            @internal_store = Hash.new { |hash, key| hash[key] = ValueWithExemplars.new }
           end
 
           def synchronize
             yield
           end
 
-          def set(labels:, val:)
-            @internal_store[labels] = val.to_f
+          def set(labels:, val:, exemplar: nil)
+            @internal_store[labels].set(value: val, exemplar: exemplar)
           end
 
-          def increment(labels:, by: 1)
-            @internal_store[labels] += by
+          def increment(labels:, by: 1, exemplar: nil)
+            @internal_store[labels].increment(by: by, exemplar: exemplar)
           end
 
-          def get(labels:)
-            @internal_store[labels]
+          def get(labels:, with_exemplars: false)
+            if with_exemplars
+              @internal_store[labels]
+            else
+              @internal_store[labels].value
+            end
           end
 
-          def all_values
-            @internal_store.dup
+          def all_values(with_exemplars: false)
+            if with_exemplars
+              @internal_store.dup
+            else
+              # this mess is just for backwards compatibility
+              output = Hash.new { |hash, key| hash[key] = 0.0 }
+              @internal_store.keys.each do |k|
+                output[k] = @internal_store[k].value
+              end
+
+              output
+            end
           end
         end
 

--- a/lib/prometheus/client/data_stores/synchronized.rb
+++ b/lib/prometheus/client/data_stores/synchronized.rb
@@ -24,7 +24,7 @@ module Prometheus
 
         class MetricStore
           def initialize
-            @internal_store = Hash.new { |hash, key| hash[key] = 0.0 }
+            @internal_store = Hash.new { |hash, key| hash[key] = ValueWithExemplars.new }
             @lock = Monitor.new
           end
 
@@ -32,26 +32,42 @@ module Prometheus
             @lock.synchronize { yield }
           end
 
-          def set(labels:, val:)
+          def set(labels:, val:, exemplar: nil)
             synchronize do
-              @internal_store[labels] = val.to_f
+              @internal_store[labels].set(value: val, exemplar: exemplar)
             end
           end
 
-          def increment(labels:, by: 1)
+          def increment(labels:, by: 1, exemplar: nil)
             synchronize do
-              @internal_store[labels] += by
+              @internal_store[labels].increment(by: by, exemplar: exemplar)
             end
           end
 
-          def get(labels:)
+          def get(labels:, with_exemplars: false)
             synchronize do
-              @internal_store[labels]
+              if with_exemplars
+                @internal_store[labels]
+              else
+                @internal_store[labels].value
+              end
             end
           end
 
-          def all_values
-            synchronize { @internal_store.dup }
+          def all_values(with_exemplars: false)
+            synchronize do
+              if with_exemplars
+                @internal_store.dup
+              else
+                # this mess is just for backwards compatibility
+                output = Hash.new { |hash, key| hash[key] = 0.0 }
+                @internal_store.keys.each do |k|
+                  output[k] = @internal_store[k].value
+                end
+
+                output
+              end
+            end
           end
         end
 

--- a/lib/prometheus/client/data_stores/synchronized.rb
+++ b/lib/prometheus/client/data_stores/synchronized.rb
@@ -1,3 +1,8 @@
+# no idea why this is reuired but giving up for now
+require 'prometheus/client/exemplar'
+require 'prometheus/client/exemplar_collection'
+require 'prometheus/client/value_with_exemplars'
+
 module Prometheus
   module Client
     module DataStores
@@ -24,7 +29,7 @@ module Prometheus
 
         class MetricStore
           def initialize
-            @internal_store = Hash.new { |hash, key| hash[key] = ValueWithExemplars.new }
+            @internal_store = Hash.new { |hash, key| hash[key] = Prometheus::Client::ValueWithExemplars.new }
             @lock = Monitor.new
           end
 

--- a/lib/prometheus/client/exemplar.rb
+++ b/lib/prometheus/client/exemplar.rb
@@ -6,7 +6,8 @@ module Prometheus
     # Store a snapshot of metric data including an extra set of kv pairs for a specific moment in
     # time and specific moment of code execution.
     #
-    # Value is expected to be set after the exemplar is initialized.
+    # Value is expected to be set after the exemplar is initialized.  Exemplars without a value will
+    # not be exported.
     class Exemplar
       # The kv pairs that make up the unique information in the exemplar.
       #
@@ -23,6 +24,10 @@ module Prometheus
       def initialize(labels: {}, timestamp: nil)
         @labels = labels
         @timestamp = timestamp || Time.now.to_i
+      end
+
+      def empty?
+        value.nil?
       end
     end
   end

--- a/lib/prometheus/client/exemplar.rb
+++ b/lib/prometheus/client/exemplar.rb
@@ -1,0 +1,17 @@
+# encoding: UTF-8
+
+module Prometheus
+  module Client
+
+    # essentially a wrapper for a hash and a timestamp
+    # maybe will hold validity checks eventually
+    class Exemplar
+      attr_reader :labels, :timestamp, :value
+      attr_writer :value
+      def initialize(labels: {}, timestamp: nil)
+        @labels = labels
+        @timestamp = timestamp || Time.now.to_i
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/exemplar.rb
+++ b/lib/prometheus/client/exemplar.rb
@@ -3,11 +3,23 @@
 module Prometheus
   module Client
 
-    # essentially a wrapper for a hash and a timestamp
-    # maybe will hold validity checks eventually
+    # Store a snapshot of metric data including an extra set of kv pairs for a specific moment in
+    # time and specific moment of code execution.
+    #
+    # Value is expected to be set after the exemplar is initialized.
     class Exemplar
-      attr_reader :labels, :timestamp, :value
+      # The kv pairs that make up the unique information in the exemplar.
+      #
+      # We generally store trace ids here
+      attr_reader :labels
+
+      # The time the exemplar was recorded
+      attr_reader :timestamp
+
+      # The value of the metric at the time the exemplar was recorded
       attr_writer :value
+      attr_reader :value
+
       def initialize(labels: {}, timestamp: nil)
         @labels = labels
         @timestamp = timestamp || Time.now.to_i

--- a/lib/prometheus/client/exemplar_collection.rb
+++ b/lib/prometheus/client/exemplar_collection.rb
@@ -3,7 +3,7 @@
 module Prometheus
   module Client
     class ExemplarCollection
-      extend Enumerable
+      include Enumerable
 
       # store the exemplars attached to a metric + label set
       def initialize
@@ -42,13 +42,18 @@ module Prometheus
         end
       end
 
+      def size
+        @exemplar_count
+      end
+
       private
       
       def cleanup_if_necessary
-        @exemplar_count += 1
-        if @exemplar_count > @max_exemplars || @collection.keys.size > @max_timestamps
+        if @exemplar_count >= @max_exemplars || @collection.keys.size >= @max_timestamps
           @exemplar_count -= @collection.delete(first_key)&.size
         end
+
+        @exemplar_count += 1
       end
       
       def first_key

--- a/lib/prometheus/client/exemplar_collection.rb
+++ b/lib/prometheus/client/exemplar_collection.rb
@@ -1,0 +1,63 @@
+# encoding: UTF-8
+
+module Prometheus
+  module Client
+    class ExemplarCollection
+      extend Enumerable
+
+      # store the exemplars attached to a metric + label set
+      def initialize
+        @collection = {}
+
+        # theoretical way to avoid causing a major memory leak
+        #
+        # This could store two minutes of requests with 2 requests per second with these settings.
+        # I am not clear on the situation where this wouldn't be enough but I am sure I will find it
+        @max_timestamps = 120
+        @max_exemplars = 240
+        @exemplar_count = 0
+      end
+
+      def add(exemplar)
+        cleanup_if_necessary
+        @collection[exemplar.timestamp] ||= []
+        @collection[exemplar.timestamp] << exemplar
+
+        exemplar
+      end
+
+      def most_recent
+        @collection[last_key]&.last
+      end
+
+      def last
+        most_recent
+      end
+
+      def each
+        @collection.keys.sort.each do |key|
+          @collection[key].each do |exemplar|
+            yield(exemplar)
+          end
+        end
+      end
+
+      private
+      
+      def cleanup_if_necessary
+        @exemplar_count += 1
+        if @exemplar_count > @max_exemplars || @collection.keys.size > @max_timestamps
+          @exemplar_count -= @collection.delete(first_key)&.size
+        end
+      end
+      
+      def first_key
+        @collection.keys.sort&.first
+      end
+
+      def last_key
+        @collection.keys.sort&.last
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -29,7 +29,7 @@ module Prometheus
           end
 
           def name
-            metric.name
+            metric.name.to_s
           end
 
           def docstring
@@ -109,6 +109,10 @@ module Prometheus
               value = value_with_exemplars.value
               exemplar = value_with_exemplars.most_recent_exemplar
               created = value_with_exemplars.created
+
+              # hack in support to remove _total from all of our counters because _total is now a
+              # reserved word
+              metric_name = name.gsub(/_total$/, "")
 
               output << metric_line(name, label_set, value, exemplar)
               output << metric_line("#{name}_created", label_set, created)

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -78,6 +78,7 @@ module Prometheus
 
               output << metric_line("#{name}_sum", label_set, value["sum"])
               output << metric_line("#{name}_count", label_set, value["+Inf"])
+              # output << metric_line("#{name}_created", label_set, created)
             end
 
             output

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -60,7 +60,6 @@ module Prometheus
             # maybe start with gauges/counters because they are easy
             output = []
 
-            require 'debug'; debugger
             metric.values.collect do |label_set, value|
               if type == :histogram
                 output << histogram(metric.name, label_set, value)

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -1,0 +1,79 @@
+# encoding: UTF-8
+
+module Prometheus
+  module Client
+    module Formats
+      module OpenMetrics
+        # used by the middleware to determine if this format works for the request
+        MEDIA_TYPE   = 'text/plain'.freeze
+        VERSION      = '0.0.1'.freeze
+        CONTENT_TYPE = "#{MEDIA_TYPE}; version=#{VERSION}".freeze
+
+        # public interface to generate out the /metrics payload
+        def self.marshal(registry)
+          lines = []
+
+          registry.metrics.each do |metric|
+            # generate metric and put it in lines
+            lines << Writer.new(metric).to_open_metrics
+          end
+
+          (lines << nil).join(DELIMITER)
+        end
+
+        # big questions
+        # - how to pull the timestamp out of the metrics repo
+        # - how to pull the right number of metrics rows for the given number of timestamps out of
+        #   the metrics repo
+        # - how to pull out exemplars (and the right number of metric rows for exemplars)
+        # - label formatting (copy from the other file)
+        # - what does a sample mean in the docs, who decides that we should sample a specific value?
+        class Writer
+          attr_reader :metric
+          def initialize(metric)
+            @metric = metric
+          end
+
+          def name
+            metric.name
+          end
+
+          def docstring
+            metric.docstring
+          end
+
+          def unit
+            metric.unit rescue "hotdogs"
+          end
+
+          # the spec has a weird conversion with hard coded constants
+          # I am not sure if they are necessary
+          # for example counter converts to %d99.111.117.110.116.101.114 which really looks like
+          # character encodings for the word counter
+          def type
+            metric.type.to_s
+          end
+
+          def metrics_to_s
+            # special case for summaries
+            # special case for histograms
+            # maybe start with gauges/counters because they are easy
+            metric.values.collect do |label_set, value|
+              "#{name}#{label_formatter(label_set)} #{value} #{metric.timestamp}"
+            end
+          end
+
+          def description
+            "# TYPE #{name} #{type}\n" \
+            "# UNIT #{name} #{unit}\n" \
+            "# HELP #{name} #{docstring}\n"
+          end
+
+          def write
+            "#{description}#{metrics_to_s}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -126,7 +126,7 @@ module Prometheus
           def metric_line(name, label_set, value, exemplar = nil)
             output = "#{name}#{labels(label_set)} #{value}"
             output += " #{timestamp}" if timestamp
-            output += " # #{labels(exemplar.labels)} #{exemplar.value} #{exemplar.timestamp}" if exemplar
+            output += " # #{labels(exemplar.labels)} #{exemplar.value} #{exemplar.timestamp}" if exemplar && !exemplar.empty?
 
             output
           end

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -57,7 +57,7 @@ module Prometheus
               output << histogram
             elsif type == :counter
               output << counter
-            else
+            else # if [:gauge].include?(type)
               metric.values(with_exemplars: true).collect do |label_set, value_with_exemplars|
                 output << metric_line(name, label_set, value_with_exemplars.value, value_with_exemplars.most_recent_exemplar)
               end

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -5,10 +5,11 @@ module Prometheus
     module Formats
       module OpenMetrics
         # used by the middleware to determine if this format works for the request
-        MEDIA_TYPE   = 'text/plain'.freeze
-        VERSION      = '0.0.1'.freeze
-        CONTENT_TYPE = "#{MEDIA_TYPE}; version=#{VERSION}".freeze
+        MEDIA_TYPE   = 'application/openmetrics-text'.freeze
+        VERSION      = '1.0.0'.freeze
+        CONTENT_TYPE = "#{MEDIA_TYPE}; version=#{VERSION}; charset=utf-8".freeze
         DELIMITER = "\n".freeze
+        EOF = "# EOF\n"
 
         # public interface to generate out the /metrics payload
         def self.marshal(registry)
@@ -19,7 +20,7 @@ module Prometheus
             lines << Writer.new(metric).write
           end
 
-          (lines.flatten.compact << nil).join(DELIMITER)
+          (lines.flatten.compact << EOF).join(DELIMITER)
         end
 
         class Writer

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -117,7 +117,7 @@ module Prometheus
             [
               "# TYPE #{name} #{type}",
               "# UNIT #{name} #{unit}",
-              "# HELP #{name} #{docstring}"
+              "# HELP #{name} #{escape(docstring, :doc)}"
             ]
           end
 

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -64,7 +64,7 @@ module Prometheus
               if type == :histogram
                 output << histogram(metric.name, label_set, value)
               else
-                output << metric_line(name, label_set, value, timestamp) # timestamp
+                output << metric_line(name, label_set, value)
               end
             end
 
@@ -86,12 +86,19 @@ module Prometheus
             output
           end
 
-          def metric_line(name, label_set, value, timestamp = nil)
+          def metric_line(name, label_set, value)
             output = "#{name}#{labels(label_set)} #{value}"
                 # require 'debug'; debugger    
-            output += " #{timestamp}" if timestamp
+            ts = timestamp(label_set)
+            output += " #{ts}" if ts
 
             output
+          end
+
+          def timestamp(set)
+            return unless set.has_key?(:_timestamp)
+
+            set[:_timestamp]
           end
 
           def labels(set)
@@ -99,7 +106,7 @@ module Prometheus
 
             output = []
 
-            set.each do |key, value|
+            set.except(:_timestamp).each do |key, value|
               output << "#{key}=\"#{escape(value, :label)}\""
             end
 
@@ -125,9 +132,6 @@ module Prometheus
             (description + metrics_to_a).join("\n")
           end
 
-          def timestamp
-            
-          end
         end
       end
     end

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -16,10 +16,10 @@ module Prometheus
 
           registry.metrics.each do |metric|
             # generate metric and put it in lines
-            lines << Writer.new(metric).metrics_to_a
+            lines << Writer.new(metric).write
           end
 
-          (lines << nil).join(DELIMITER)
+          (lines.flatten.compact << nil).join(DELIMITER)
         end
 
         class Writer
@@ -165,7 +165,7 @@ module Prometheus
           end
 
           def write
-            (description + metrics_to_a).join("\n")
+            (description + metrics_to_a).flatten.join(Prometheus::Client::Formats::OpenMetrics::DELIMITER)
           end
 
         end

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -8,6 +8,7 @@ module Prometheus
         MEDIA_TYPE   = 'text/plain'.freeze
         VERSION      = '0.0.1'.freeze
         CONTENT_TYPE = "#{MEDIA_TYPE}; version=#{VERSION}".freeze
+        DELIMITER = "\n".freeze
 
         # public interface to generate out the /metrics payload
         def self.marshal(registry)
@@ -15,7 +16,7 @@ module Prometheus
 
           registry.metrics.each do |metric|
             # generate metric and put it in lines
-            lines << Writer.new(metric).to_open_metrics
+            lines << Writer.new(metric).metrics_to_a
           end
 
           (lines << nil).join(DELIMITER)

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -90,11 +90,10 @@ module Prometheus
           def summary
             output = []
 
-            metric.values.collect do |label_set, value|
-              output << metric_line("#{name}_sum", label_set, value["sum"])
-              output << metric_line("#{name}_count", label_set, value["count"])
-              # created is dependent on the exemplar working
-              # output << metric_line("#{name}_created", label_set, created)
+            metric.values.collect do |label_set, vwe|
+              output << metric_line("#{name}_sum", label_set, vwe.value["sum"], vwe.most_recent_exemplar)
+              output << metric_line("#{name}_count", label_set, vwe.value["count"], vwe.most_recent_exemplar)
+              output << metric_line("#{name}_created", label_set, vwe.created)
             end
 
             output

--- a/lib/prometheus/client/formats/open_metrics.rb
+++ b/lib/prometheus/client/formats/open_metrics.rb
@@ -60,11 +60,12 @@ module Prometheus
             # maybe start with gauges/counters because they are easy
             output = []
 
+            require 'debug'; debugger
             metric.values.collect do |label_set, value|
               if type == :histogram
                 output << histogram(metric.name, label_set, value)
               else
-                output << metric_line(name, label_set, value) # timestamp
+                output << metric_line(name, label_set, value, timestamp) # timestamp
               end
             end
 
@@ -88,6 +89,7 @@ module Prometheus
 
           def metric_line(name, label_set, value, timestamp = nil)
             output = "#{name}#{labels(label_set)} #{value}"
+                # require 'debug'; debugger    
             output += " #{timestamp}" if timestamp
 
             output
@@ -122,6 +124,10 @@ module Prometheus
 
           def write
             (description + metrics_to_a).join("\n")
+          end
+
+          def timestamp
+            
           end
         end
       end

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -51,8 +51,8 @@ module Prometheus
 
           def summary(name, set, value)
             l = labels(set)
-            yield metric("#{name}_sum", l, value["sum"])
-            yield metric("#{name}_count", l, value["count"])
+            yield metric("#{name}_sum", l, value.value["sum"])
+            yield metric("#{name}_count", l, value.value["count"])
           end
 
           def histogram(name, set, value)

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -6,7 +6,7 @@ module Prometheus
       # Text format is human readable mainly used for manual inspection.
       module Text
         MEDIA_TYPE   = 'text/plain'.freeze
-        VERSION      = '0.0.4'.freeze
+        VERSION      = '0.0.1'.freeze
         CONTENT_TYPE = "#{MEDIA_TYPE}; version=#{VERSION}".freeze
 
         METRIC_LINE = '%s%s %s'.freeze

--- a/lib/prometheus/client/gauge.rb
+++ b/lib/prometheus/client/gauge.rb
@@ -12,26 +12,26 @@ module Prometheus
       end
 
       # Sets the value for the given label set
-      def set(value, labels: {})
+      def set(value, labels: {}, exemplar: nil)
         unless value.is_a?(Numeric)
           raise ArgumentError, 'value must be a number'
         end
 
-        @store.set(labels: label_set_for(labels), val: value)
+        @store.set(labels: label_set_for(labels), val: value, exemplar: nil)
       end
 
       # Increments Gauge value by 1 or adds the given value to the Gauge.
       # (The value can be negative, resulting in a decrease of the Gauge.)
-      def increment(by: 1, labels: {})
+      def increment(by: 1, labels: {}, exemplar: nil)
         label_set = label_set_for(labels)
-        @store.increment(labels: label_set, by: by)
+        @store.increment(labels: label_set, by: by, exemplar: nil)
       end
 
       # Decrements Gauge value by 1 or subtracts the given value from the Gauge.
       # (The value can be negative, resulting in a increase of the Gauge.)
-      def decrement(by: 1, labels: {})
+      def decrement(by: 1, labels: {}, exemplar: nil)
         label_set = label_set_for(labels)
-        @store.increment(labels: label_set, by: -by)
+        @store.increment(labels: label_set, by: -by, exemplar: nil)
       end
     end
   end

--- a/lib/prometheus/client/gauge.rb
+++ b/lib/prometheus/client/gauge.rb
@@ -17,21 +17,21 @@ module Prometheus
           raise ArgumentError, 'value must be a number'
         end
 
-        @store.set(labels: label_set_for(labels), val: value, exemplar: nil)
+        @store.set(labels: label_set_for(labels), val: value, exemplar: exemplar)
       end
 
       # Increments Gauge value by 1 or adds the given value to the Gauge.
       # (The value can be negative, resulting in a decrease of the Gauge.)
       def increment(by: 1, labels: {}, exemplar: nil)
         label_set = label_set_for(labels)
-        @store.increment(labels: label_set, by: by, exemplar: nil)
+        @store.increment(labels: label_set, by: by, exemplar: exemplar)
       end
 
       # Decrements Gauge value by 1 or subtracts the given value from the Gauge.
       # (The value can be negative, resulting in a increase of the Gauge.)
       def decrement(by: 1, labels: {}, exemplar: nil)
         label_set = label_set_for(labels)
-        @store.increment(labels: label_set, by: -by, exemplar: nil)
+        @store.increment(labels: label_set, by: -by, exemplar: exemplar)
       end
     end
   end

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -66,7 +66,7 @@ module Prometheus
       # in the sum of observations. See
       # https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations
       # for details.
-      def observe(value, labels: {})
+      def observe(value, labels: {}, exemplar: nil)
         bucket = buckets.find {|upper_limit| upper_limit >= value  }
         bucket = "+Inf" if bucket.nil?
 
@@ -79,8 +79,8 @@ module Prometheus
         sum_label_set[:le] = "sum"
 
         @store.synchronize do
-          @store.increment(labels: bucket_label_set, by: 1)
-          @store.increment(labels: sum_label_set, by: value)
+          @store.increment(labels: bucket_label_set, by: 1, exemplar: exemplar)
+          @store.increment(labels: sum_label_set, by: value, exemplar: exemplar)
         end
       end
 

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -2,19 +2,20 @@
 
 require 'thread'
 require 'prometheus/client/label_set_validator'
+require 'prometheus/client/exemplar'
+require 'prometheus/client/exemplar_collection'
 
 module Prometheus
   module Client
     # Metric
     class Metric
-      attr_reader :name, :docstring, :labels, :preset_labels, :timestamp
+      attr_reader :name, :docstring, :labels, :preset_labels, :created_at
 
       def initialize(name,
                      docstring:,
                      labels: [],
                      preset_labels: {},
-                     store_settings: {},
-                     timestamp: nil)
+                     store_settings: {})
 
         validate_name(name)
         validate_docstring(docstring)
@@ -41,6 +42,8 @@ module Prometheus
           metric_type: type,
           metric_settings: store_settings
         )
+
+        @created_at = Time.now.to_i
 
         # WARNING: Our internal store can be replaced later by `with_labels`
         # Everything we do after this point needs to still work if @store gets replaced
@@ -77,8 +80,8 @@ module Prometheus
       end
 
       # Returns all label sets with their values
-      def values
-        @store.all_values
+      def values(with_exemplars: false)
+        @store.all_values(with_exemplars: with_exemplars)
       end
 
       private

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -9,7 +9,7 @@ module Prometheus
   module Client
     # Metric
     class Metric
-      attr_reader :name, :docstring, :labels, :preset_labels
+      attr_reader :name, :docstring, :labels, :preset_labels, :unit
 
       def initialize(name,
                      docstring:,
@@ -30,6 +30,7 @@ module Prometheus
         @name = name
         @docstring = docstring
         @preset_labels = stringify_values(preset_labels)
+        @unit = nil # not fully supported yet
 
         @all_labels_preset = false
         if preset_labels.keys.length == labels.length

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -7,13 +7,14 @@ module Prometheus
   module Client
     # Metric
     class Metric
-      attr_reader :name, :docstring, :labels, :preset_labels
+      attr_reader :name, :docstring, :labels, :preset_labels, :timestamp
 
       def initialize(name,
                      docstring:,
                      labels: [],
                      preset_labels: {},
-                     store_settings: {})
+                     store_settings: {},
+                     timestamp: nil)
 
         validate_name(name)
         validate_docstring(docstring)

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -9,7 +9,7 @@ module Prometheus
   module Client
     # Metric
     class Metric
-      attr_reader :name, :docstring, :labels, :preset_labels, :created_at
+      attr_reader :name, :docstring, :labels, :preset_labels
 
       def initialize(name,
                      docstring:,
@@ -42,8 +42,6 @@ module Prometheus
           metric_type: type,
           metric_settings: store_settings
         )
-
-        @created_at = Time.now.to_i
 
         # WARNING: Our internal store can be replaced later by `with_labels`
         # Everything we do after this point needs to still work if @store gets replaced

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -37,12 +37,13 @@ module Prometheus
         end
       end
 
-      def counter(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
+      def counter(name, docstring:, labels: [], preset_labels: {}, store_settings: {}, timestamp: nil)
         register(Counter.new(name,
                              docstring: docstring,
                              labels: labels,
                              preset_labels: preset_labels,
-                             store_settings: store_settings))
+                             store_settings: store_settings,
+                             timestamp: timestamp))
       end
 
       def summary(name, docstring:, labels: [], preset_labels: {}, store_settings: {})

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -37,13 +37,12 @@ module Prometheus
         end
       end
 
-      def counter(name, docstring:, labels: [], preset_labels: {}, store_settings: {}, timestamp: nil)
+      def counter(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Counter.new(name,
                              docstring: docstring,
                              labels: labels,
                              preset_labels: preset_labels,
-                             store_settings: store_settings,
-                             timestamp: timestamp))
+                             store_settings: store_settings))
       end
 
       def summary(name, docstring:, labels: [], preset_labels: {}, store_settings: {})

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -40,13 +40,36 @@ module Prometheus
       end
 
       # Returns all label sets with their values expressed as hashes with their sum/count
+      #
+      # Converts from
+      # {
+      #   {<labels>, :quantile=>"count"} => <value>,
+      #   {<labels>, :quantile=>"sum"} => <value>
+      # }
+      # to
+      # {
+      #   <labels>: {count: <value>, sum: <value>}
+      # }
+      #
+      # This isn't going to work long term because it isn't possible to differentiate between
+      # exemplars whose value is based on the count and exemplars whose value is based on the sum.
+      # For now, it is random/unusable.
       def values
-        values = @store.all_values
+        values = @store.all_values(with_exemplars: true)
 
-        values.each_with_object({}) do |(label_set, v), acc|
+        values.each_with_object({}) do |(label_set, value_with_exemplars), acc|
           actual_label_set = label_set.reject{|l| l == :quantile }
-          acc[actual_label_set] ||= { "count" => 0.0, "sum" => 0.0 }
-          acc[actual_label_set][label_set[:quantile]] = v
+
+          if acc.has_key? actual_label_set
+            acc[actual_label_set].value[label_set[:quantile]] = value_with_exemplars.value
+          else
+            new_vwe = ValueWithExemplars.new
+            value = { "count" => 0.0, "sum" => 0.0 }.merge({ label_set[:quantile] => value_with_exemplars.value })
+            new_vwe.value = value
+            new_vwe.exemplars = value_with_exemplars.exemplars # only copy over the exemplars once because both quantiles have the same exemplars
+
+            acc[actual_label_set] = new_vwe
+          end
         end
       end
 

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -17,12 +17,12 @@ module Prometheus
       # in the sum of observations. See
       # https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations
       # for details.
-      def observe(value, labels: {})
+      def observe(value, labels: {}, exemplar: nil)
         base_label_set = label_set_for(labels)
 
         @store.synchronize do
-          @store.increment(labels: base_label_set.merge(quantile: "count"), by: 1)
-          @store.increment(labels: base_label_set.merge(quantile: "sum"), by: value)
+          @store.increment(labels: base_label_set.merge(quantile: "count"), by: 1, exemplar: exemplar)
+          @store.increment(labels: base_label_set.merge(quantile: "sum"), by: value, exemplar: exemplar)
         end
       end
 

--- a/lib/prometheus/client/value_with_exemplars.rb
+++ b/lib/prometheus/client/value_with_exemplars.rb
@@ -1,0 +1,44 @@
+# encoding: UTF-8
+
+module Prometheus
+  module Client
+    # stores a value for a label permutation on a metric along with all the exemplars that match the
+    # labels.
+    #
+    # The labels are actually stored somewhere else.  Maybe we could duplicate them here?
+    #
+    # no idea how this is going to work with histograms
+    class ValueWithExemplars
+      attr_reader :value, :exemplar
+
+      def initialize
+        @exemplars = ExemplarCollection.new
+        @value = 0.0
+      end
+
+      def most_recent_exemplar
+        @exemplars.most_recent
+      end
+
+      def set(value:, exemplar:)
+        @value = value.to_f
+        if exemplar
+          exemplar.value = @value # not convinced this line goes in this file
+          @exemplars.add(exemplar)
+        end
+
+        @value
+      end
+
+      def increment(by: 1, exemplar:)
+        @value += by
+        if exemplar
+          exemplar.value = @value # not convinced this line goes in this file
+          @exemplars.add(exemplar)
+        end
+
+        @value
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/value_with_exemplars.rb
+++ b/lib/prometheus/client/value_with_exemplars.rb
@@ -28,7 +28,7 @@ module Prometheus
         @exemplars.most_recent
       end
 
-      def set(value:, exemplar:)
+      def set(value:, exemplar: nil)
         @value = value.to_f
         if exemplar
           exemplar.value = @value # not convinced this line goes in this file
@@ -38,7 +38,7 @@ module Prometheus
         @value
       end
 
-      def increment(by: 1, exemplar:)
+      def increment(by: 1, exemplar: nil)
         @value += by
         if exemplar
           exemplar.value = @value # not convinced this line goes in this file

--- a/lib/prometheus/client/value_with_exemplars.rb
+++ b/lib/prometheus/client/value_with_exemplars.rb
@@ -9,7 +9,8 @@ module Prometheus
     #
     # no idea how this is going to work with histograms
     class ValueWithExemplars
-      attr_reader :value, :exemplar, :created
+      # changed from reader to accessor to make object setup easier for summaries
+      attr_accessor :value, :exemplars, :created
 
       def initialize
         @exemplars = ExemplarCollection.new

--- a/lib/prometheus/client/value_with_exemplars.rb
+++ b/lib/prometheus/client/value_with_exemplars.rb
@@ -9,11 +9,19 @@ module Prometheus
     #
     # no idea how this is going to work with histograms
     class ValueWithExemplars
-      attr_reader :value, :exemplar
+      attr_reader :value, :exemplar, :created
 
       def initialize
         @exemplars = ExemplarCollection.new
         @value = 0.0
+
+        # slightly confused on the spec for this one
+        # One reading is that the created timestamp is on a per label set/metricpoint basis, not per
+        # metric.  I also wrote a parallel change that adds the created to the constructor in
+        # metric.rb and decided to remove it based on the spec interpretation.
+        #
+        # Floating point time is used to match the spec examples
+        @created = Time.now.to_f
       end
 
       def most_recent_exemplar

--- a/lib/prometheus/middleware/exporter.rb
+++ b/lib/prometheus/middleware/exporter.rb
@@ -2,6 +2,7 @@
 
 require 'prometheus/client'
 require 'prometheus/client/formats/text'
+require 'prometheus/client/formats/open_metrics'
 
 module Prometheus
   module Middleware

--- a/lib/prometheus/middleware/exporter.rb
+++ b/lib/prometheus/middleware/exporter.rb
@@ -15,6 +15,8 @@ module Prometheus
     class Exporter
       attr_reader :app, :registry, :path
 
+      # this file does not support multiple formats
+      # I am officially giving up
       FORMATS  = [Client::Formats::OpenMetrics].freeze
       FALLBACK = Client::Formats::OpenMetrics
 
@@ -78,7 +80,7 @@ module Prometheus
         [
           406,
           { 'content-type' => 'text/plain' },
-          ["Supported media types: #{types.join(', ')}"],
+          ["Supported media types: #{types.uniq.join(', ')}"],
         ]
       end
 

--- a/lib/prometheus/middleware/exporter.rb
+++ b/lib/prometheus/middleware/exporter.rb
@@ -15,8 +15,8 @@ module Prometheus
     class Exporter
       attr_reader :app, :registry, :path
 
-      FORMATS  = [Client::Formats::Text].freeze
-      FALLBACK = Client::Formats::Text
+      FORMATS  = [Client::Formats::OpenMetrics].freeze
+      FALLBACK = Client::Formats::OpenMetrics
 
       def initialize(app, options = {})
         @app = app

--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'benchmark-ips'
   s.add_development_dependency 'concurrent-ruby'
+  s.add_development_dependency 'pry-byebug'
 end

--- a/spec/prometheus/client/exemplar_collection_spec.rb
+++ b/spec/prometheus/client/exemplar_collection_spec.rb
@@ -1,0 +1,60 @@
+# encoding: UTF-8
+
+require 'prometheus/client/exemplar'
+require 'prometheus/client/exemplar_collection'
+
+describe Prometheus::Client::ExemplarCollection do
+  describe "add" do
+    it "adds an exemplar" do
+      collection = described_class.new
+
+      exemplar = Prometheus::Client::Exemplar.new(labels: {hotdogs: "great"}, timestamp: 1)
+      collection.add(exemplar)
+
+      expect(collection.first).to eq(exemplar)
+    end
+
+    it "cleans up if necessary" do
+      collection = described_class.new
+
+      120.times do |index|
+        exemplar = Prometheus::Client::Exemplar.new(labels: {hotdogs: "great"}, timestamp: index)
+        collection.add(exemplar)
+      end
+
+      expect(collection.size).to eq(120)
+
+      exemplar = Prometheus::Client::Exemplar.new(labels: {hotdogs: "great"}, timestamp: 1000)
+      collection.add(exemplar)
+
+      expect(collection.size).to eq(120)
+      expect(collection.most_recent.timestamp).to eq(1000)
+    end
+  end
+
+  describe "most_recent" do
+    it "returns the most recent exemplar by timestamp" do
+      collection = described_class.new
+
+      exemplar_1 = Prometheus::Client::Exemplar.new(labels: {hotdogs: "great"}, timestamp: 10)
+      collection.add(exemplar_1)
+
+      exemplar_2 = Prometheus::Client::Exemplar.new(labels: {hotdogs: "bad"}, timestamp: 5)
+      collection.add(exemplar_2)
+
+      expect(collection.most_recent).to eq(exemplar_1)
+    end
+
+    it "returns the most recently written exemplar if there is a timestamp tie" do
+      collection = described_class.new
+
+      exemplar_1 = Prometheus::Client::Exemplar.new(labels: {hotdogs: "great"}, timestamp: 1)
+      collection.add(exemplar_1)
+
+      exemplar_2 = Prometheus::Client::Exemplar.new(labels: {hotdogs: "bad"}, timestamp: 1)
+      collection.add(exemplar_2)
+
+      expect(collection.most_recent).to eq(exemplar_2)
+    end
+  end
+end

--- a/spec/prometheus/client/exemplar_spec.rb
+++ b/spec/prometheus/client/exemplar_spec.rb
@@ -14,4 +14,13 @@ describe Prometheus::Client::Exemplar do
 
     expect(e.timestamp).to be <= Time.now.to_i
   end
+
+  it "is empty" do
+    e = described_class.new
+
+    expect(e).to be_empty
+
+    e.value = 5
+    expect(e).not_to be_empty
+  end
 end

--- a/spec/prometheus/client/exemplar_spec.rb
+++ b/spec/prometheus/client/exemplar_spec.rb
@@ -1,0 +1,17 @@
+# encoding: UTF-8
+
+require 'prometheus/client/exemplar'
+
+describe Prometheus::Client::Exemplar do
+  it "sets default labels" do
+    e = described_class.new
+
+    expect(e.labels).to eq({})
+  end
+
+  it "sets a default timestamp" do
+    e = described_class.new
+
+    expect(e.timestamp).to be <= Time.now.to_i
+  end
+end

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -46,7 +46,28 @@ describe Prometheus::Client::Formats::OpenMetrics do
         expect(lines).to include("counter_without_ts{umlauts=\"Björn\",utf=\"佖佥\",code=\"blue\"} 1.23e-45")
       end
 
-      it "generates a metric with a timestamp"
+      let(:counter_with_ts) do
+        counter_with_ts = registry.counter(:counter_with_ts,
+                               docstring: 'foo description',
+                               labels: [:umlauts, :utf, :code],
+                               preset_labels: {umlauts: 'Björn', utf: '佖佥'},
+                               timestamp: 1686111748)
+        counter_with_ts.increment(labels: { code: 'red'}, by: 42)
+        counter_with_ts.increment(labels: { code: 'green'}, by: 3.14E42)
+        counter_with_ts.increment(labels: { code: 'blue'}, by: 1.23e-45)
+        counter_with_ts
+
+      end
+
+      it "generates a metric with a timestamp" do
+        require 'debug'; debugger
+        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(counter_with_ts)
+
+        lines = writer.write.split("\n")
+
+
+      end
+
       it "generates a metric with an exemplar"
     end
 
@@ -85,7 +106,9 @@ describe Prometheus::Client::Formats::OpenMetrics do
         expect(lines).to include("histogram_without_ts_sum{code=\"ah\"} 15.2")
         expect(lines).to include("histogram_without_ts_count{code=\"ah\"} 2.0")
       end
-      it "generates a metric with a timestamp"
+      it "generates a metric with a timestamp" do
+        
+      end
       it "generates a metric with an exemplar"
     end
 
@@ -103,12 +126,23 @@ describe Prometheus::Client::Formats::OpenMetrics do
       it "generates a metric with an exemplar"
     end
 
-    describe "summary" do
-      it "generates a metric description"
-      it "generates a metric without a timestamp"
-      it "generates a metric with a timestamp"
-      it "generates a metric with an exemplar"
-    end
+    # describe "summary" do
+    #   let(:registry.summary(:summary)) do
+    #     counter_without_ts = registry.counter(:counter_without_ts,
+    #                            docstring: 'foo description',
+    #                            labels: [:umlauts, :utf, :code],
+    #                            preset_labels: {umlauts: 'Björn', utf: '佖佥'})
+    #     counter_without_ts.increment(labels: { code: 'red'}, by: 42)
+    #     counter_without_ts.increment(labels: { code: 'green'}, by: 3.14E42)
+    #     counter_without_ts.increment(labels: { code: 'blue'}, by: 1.23e-45)
+    #
+    #     counter_without_ts
+    #   end
+    #   it "generates a metric description"
+    #   it "generates a metric without a timestamp"
+    #   it "generates a metric with a timestamp"
+    #   it "generates a metric with an exemplar"
+    # end
 
     describe "info" do
       it "generates a metric description"

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -100,6 +100,8 @@ describe Prometheus::Client::Formats::OpenMetrics do
         blue_created = counter_with_exemplars.values(with_exemplars: true)[{:umlauts=>"Björn", :utf=>"佖佥", :code=>"blue"}].created
         expect(lines).to include("counter_with_exemplars_created{umlauts=\"Björn\",utf=\"佖佥\",code=\"blue\"} #{blue_created}")
       end
+
+      it "does not write an exemplar with no value"
     end
 
     describe "gauge" do

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -87,8 +87,7 @@ describe Prometheus::Client::Formats::OpenMetrics do
 
         expect(lines).to include("# TYPE gauge_without_ts gauge")
         expect(lines).to include("# UNIT gauge_without_ts hotdogs")
-        # I think the \n should be escaped
-        expect(lines).to include("# HELP gauge_without_ts bar description\nwith newline")
+        expect(lines).to include("# HELP gauge_without_ts bar description\\nwith newline")
       end
 
       it "generates a metric without a timestamp" do

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -49,22 +49,22 @@ describe Prometheus::Client::Formats::OpenMetrics do
       let(:counter_with_ts) do
         counter_with_ts = registry.counter(:counter_with_ts,
                                docstring: 'foo description',
-                               labels: [:umlauts, :utf, :code],
-                               preset_labels: {umlauts: 'Björn', utf: '佖佥'},
-                               timestamp: 1686111748)
-        counter_with_ts.increment(labels: { code: 'red'}, by: 42, timestamp: Time.now.to_i)
-        counter_with_ts.increment(labels: { code: 'green'}, by: 3.14E42, timestamp: Time.now.to_i)
-        counter_with_ts.increment(labels: { code: 'blue'}, by: 1.23e-45, timestamp: Time.now.to_i + 1)
-        counter_with_ts
+                               labels: [:umlauts, :utf, :code, :_timestamp],
+                               preset_labels: {umlauts: 'Björn', utf: '佖佥'})
+        counter_with_ts.increment(labels: { code: 'red', _timestamp: 1000000}, by: 42)
+        counter_with_ts.increment(labels: { code: 'red', _timestamp: 1000000}, by: 1)
+        counter_with_ts.increment(labels: { code: 'blue', _timestamp: 1000001}, by: 1.23e-45)
 
+        counter_with_ts
       end
 
-      xit "generates a metric with a timestamp" do
+      it "generates a metric with a timestamp" do
         writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(counter_with_ts)
 
         lines = writer.write.split("\n")
 
-        expect(lines).to include("???")
+        expect(lines).to include("counter_with_ts{umlauts=\"Björn\",utf=\"佖佥\",code=\"red\"} 43.0 1000000")
+        expect(lines).to include("counter_with_ts{umlauts=\"Björn\",utf=\"佖佥\",code=\"blue\"} 1.23e-45 1000001")
       end
 
       xit "generates a metric with an exemplar"

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -15,21 +15,6 @@ describe Prometheus::Client::Formats::OpenMetrics do
 
   let(:registry) { Prometheus::Client::Registry.new }
 
-  it "created should not have any labels"
-  it "If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name."
-  it "If more than one MetricPoint is exposed for a Metric, the ordering should be by label permutation, then by oldest to newest timestamp"
-    # for example
-    # # TYPE foo_seconds summary
-    # # UNIT foo_seconds seconds
-    # foo_seconds_count{a="bb"} 0 123
-    # foo_seconds_sum{a="bb"} 0 123
-    # foo_seconds_count{a="bb"} 0 456
-    # foo_seconds_sum{a="bb"} 0 456
-    # foo_seconds_count{a="ccc"} 0 123
-    # foo_seconds_sum{a="ccc"} 0 123
-    # foo_seconds_count{a="ccc"} 0 456
-    # foo_seconds_sum{a="ccc"} 0 456
-
   describe "metric writers" do
     describe "counter" do
       let(:counter_metric) do

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -12,6 +12,7 @@ describe Prometheus::Client::Formats::OpenMetrics do
 
   let(:registry) { Prometheus::Client::Registry.new }
 
+  it "created should not have any labels"
   it "If a unit is specified it MUST be provided in a UNIT metadata line. In addition, an underscore and the unit MUST be the suffix of the MetricFamily name."
   it "If more than one MetricPoint is exposed for a Metric, the ordering should be by label permutation, then by oldest to newest timestamp"
     # for example
@@ -164,12 +165,13 @@ describe Prometheus::Client::Formats::OpenMetrics do
       end
       it "generates a metric with an exemplar"
 
-      it "A Histogram MetricPoint MUST contain at least one bucket, and SHOULD contain Sum, and Created values. Every bucket MUST have a threshold and a value."
-      it "Histogram MetricPoints MUST have one bucket with an +Inf threshold."
-      it "Buckets MUST be cumulative. As an example for a metric representing request latency in seconds its values for buckets with thresholds 1, 2, 3, and +Inf MUST follow value_1 <= value_2 <= value_3 <= value_+Inf. If ten requests took 1 second each, the values of the 1, 2, 3, and +Inf buckets MUST equal 10."
-      it "The +Inf bucket counts all requests. If present, the Sum value MUST equal the Sum of all the measured event values. Bucket thresholds within a MetricPoint MUST be unique."
-      it "Semantically, Sum, and buckets values are counters so MUST NOT be NaN or negative. Negative threshold buckets MAY be used, but then the Histogram MetricPoint MUST NOT contain a sum value as it would no longer be a counter semantically. Bucket thresholds MUST NOT equal NaN. Count and bucket values MUST be integers."
-      it "A Histogram MetricPoint SHOULD have a Timestamp value called Created. This can help ingestors discern between new metrics and long-running ones it did not see before."
+      it "generates a metric with at least one bucket, sum, created, and count metric points"
+      it "generates a bucket with a +Inf threshold that counts all values"
+      it "generates cumulative buckets, a low value increments the count in all buckets with higher values"
+      it "generates a sum that equals the sum of all measured event values"
+      it "if there is a negative valued bucket, there should be no sum metric"
+      it "is not clear if we should print the bucket multiple times with different timestamps to expose multiple exemplars"
+      
       it "A Histogram's Metric's LabelSet MUST NOT have a 'le' label name."
       it "Bucket values MAY have exemplars. Buckets are cumulative to allow monitoring systems to drop any non-+Inf bucket for performance/anti-denial-of-service reasons in a way that loses granularity but is still a valid Histogram."
       it "Each bucket covers the values less and or equal to it, and the value of the exemplar MUST be within this range. Exemplars SHOULD be put into the bucket with the highest value. A bucket MUST NOT have more than one exemplar."

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -52,22 +52,54 @@ describe Prometheus::Client::Formats::OpenMetrics do
                                labels: [:umlauts, :utf, :code],
                                preset_labels: {umlauts: 'Björn', utf: '佖佥'},
                                timestamp: 1686111748)
-        counter_with_ts.increment(labels: { code: 'red'}, by: 42)
-        counter_with_ts.increment(labels: { code: 'green'}, by: 3.14E42)
-        counter_with_ts.increment(labels: { code: 'blue'}, by: 1.23e-45)
+        counter_with_ts.increment(labels: { code: 'red'}, by: 42, timestamp: Time.now.to_i)
+        counter_with_ts.increment(labels: { code: 'green'}, by: 3.14E42, timestamp: Time.now.to_i)
+        counter_with_ts.increment(labels: { code: 'blue'}, by: 1.23e-45, timestamp: Time.now.to_i + 1)
         counter_with_ts
 
       end
 
-      it "generates a metric with a timestamp" do
-        require 'debug'; debugger
+      xit "generates a metric with a timestamp" do
         writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(counter_with_ts)
 
         lines = writer.write.split("\n")
 
-
+        expect(lines).to include("???")
       end
 
+      xit "generates a metric with an exemplar"
+    end
+
+    describe "gauge" do
+      let :gauge_without_ts do
+        bar = registry.gauge(:gauge_without_ts,
+                             docstring: "bar description\nwith newline",
+                             labels: [:status, :code])
+        bar.set(15, labels: { status: 'success', code: 'pink'})
+
+        bar
+      end
+
+      it "generates a metric description" do
+        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(gauge_without_ts)
+
+        lines = writer.write.split("\n")
+
+        expect(lines).to include("# TYPE gauge_without_ts gauge")
+        expect(lines).to include("# UNIT gauge_without_ts hotdogs")
+        # I think the \n should be escaped
+        expect(lines).to include("# HELP gauge_without_ts bar description\nwith newline")
+      end
+
+      it "generates a metric without a timestamp" do
+        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(gauge_without_ts)
+
+        lines = writer.write.split("\n")
+
+        expect(lines).to include("gauge_without_ts{status=\"success\",code=\"pink\"} 15.0")
+      end
+
+      it "generates a metric with a timestamp"
       it "generates a metric with an exemplar"
     end
 

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -1,0 +1,84 @@
+# encoding: UTF-8
+
+require 'prometheus/client'
+require 'prometheus/client/registry'
+require 'prometheus/client/formats/open_metrics'
+
+describe Prometheus::Client::Formats::OpenMetrics do
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::Synchronized.new
+  end
+
+  let(:registry) { Prometheus::Client::Registry.new }
+
+  describe "metric writers" do
+    describe "counter" do
+      before do
+        @foo = registry.counter(:foo,
+                               docstring: 'foo description',
+                               labels: [:umlauts, :utf, :code],
+                               preset_labels: {umlauts: 'Björn', utf: '佖佥'})
+        @foo.increment(labels: { code: 'red'}, by: 42)
+        @foo.increment(labels: { code: 'green'}, by: 3.14E42)
+        @foo.increment(labels: { code: 'blue'}, by: 1.23e-45)
+      end
+
+      it "generates a metric description" do
+        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(@foo)
+
+        lines = writer.write.split("\n")
+
+        expect(lines).to include("# TYPE foo counter")
+        expect(lines).to include("# UNIT foo hotdogs")
+        expect(lines).to include("# HELP foo foo description")
+      end
+
+      it "generates a metric without a timestamp"
+      it "generates a metric with a timestamp"
+      it "generates a metric with an exemplar"
+    end
+
+    describe "histogram" do
+      it "generates a metric description"
+      it "generates a metric without a timestamp"
+      it "generates a metric with a timestamp"
+      it "generates a metric with an exemplar"
+    end
+
+    describe "gaugehistogram" do
+      it "generates a metric description"
+      it "generates a metric without a timestamp"
+      it "generates a metric with a timestamp"
+      it "generates a metric with an exemplar"
+    end
+
+    describe "stateset" do
+      it "generates a metric description"
+      it "generates a metric without a timestamp"
+      it "generates a metric with a timestamp"
+      it "generates a metric with an exemplar"
+    end
+
+    describe "summary" do
+      it "generates a metric description"
+      it "generates a metric without a timestamp"
+      it "generates a metric with a timestamp"
+      it "generates a metric with an exemplar"
+    end
+
+    describe "info" do
+      it "generates a metric description"
+      it "generates a metric without a timestamp"
+      it "generates a metric with a timestamp"
+      it "generates a metric with an exemplar"
+    end
+
+    describe "unknown" do
+      it "generates a metric description"
+      it "generates a metric without a timestamp"
+      it "generates a metric with a timestamp"
+      it "generates a metric with an exemplar"
+    end
+  end
+end

--- a/spec/prometheus/client/formats/open_metrics_spec.rb
+++ b/spec/prometheus/client/formats/open_metrics_spec.rb
@@ -14,34 +14,77 @@ describe Prometheus::Client::Formats::OpenMetrics do
 
   describe "metric writers" do
     describe "counter" do
-      before do
-        @foo = registry.counter(:foo,
+      let(:counter_without_ts) do
+        counter_without_ts = registry.counter(:counter_without_ts,
                                docstring: 'foo description',
                                labels: [:umlauts, :utf, :code],
                                preset_labels: {umlauts: 'Björn', utf: '佖佥'})
-        @foo.increment(labels: { code: 'red'}, by: 42)
-        @foo.increment(labels: { code: 'green'}, by: 3.14E42)
-        @foo.increment(labels: { code: 'blue'}, by: 1.23e-45)
+        counter_without_ts.increment(labels: { code: 'red'}, by: 42)
+        counter_without_ts.increment(labels: { code: 'green'}, by: 3.14E42)
+        counter_without_ts.increment(labels: { code: 'blue'}, by: 1.23e-45)
+
+        counter_without_ts
       end
 
       it "generates a metric description" do
-        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(@foo)
+        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(counter_without_ts)
 
         lines = writer.write.split("\n")
 
-        expect(lines).to include("# TYPE foo counter")
-        expect(lines).to include("# UNIT foo hotdogs")
-        expect(lines).to include("# HELP foo foo description")
+        expect(lines).to include("# TYPE counter_without_ts counter")
+        expect(lines).to include("# UNIT counter_without_ts hotdogs")
+        expect(lines).to include("# HELP counter_without_ts foo description")
       end
 
-      it "generates a metric without a timestamp"
+      it "generates a metric without a timestamp" do
+        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(counter_without_ts)
+
+        lines = writer.write.split("\n")
+
+        expect(lines).to include("counter_without_ts{umlauts=\"Björn\",utf=\"佖佥\",code=\"red\"} 42.0")
+        expect(lines).to include("counter_without_ts{umlauts=\"Björn\",utf=\"佖佥\",code=\"green\"} 3.14e+42")
+        expect(lines).to include("counter_without_ts{umlauts=\"Björn\",utf=\"佖佥\",code=\"blue\"} 1.23e-45")
+      end
+
       it "generates a metric with a timestamp"
       it "generates a metric with an exemplar"
     end
 
     describe "histogram" do
-      it "generates a metric description"
-      it "generates a metric without a timestamp"
+      let(:histogram_without_ts) do
+        xuq = registry.histogram(:histogram_without_ts,
+                                 docstring: 'xuq description',
+                                 labels: [:code],
+                                 preset_labels: {code: 'ah'},
+                                 buckets: [10, 20, 30])
+        xuq.observe(12)
+        xuq.observe(3.2)
+
+        xuq
+      end
+
+      it "generates a metric description" do
+        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(histogram_without_ts)
+
+        lines = writer.write.split("\n")
+
+        expect(lines).to include("# TYPE histogram_without_ts histogram")
+        expect(lines).to include("# UNIT histogram_without_ts hotdogs")
+        expect(lines).to include("# HELP histogram_without_ts xuq description")
+      end
+
+      it "generates a metric without a timestamp" do
+        writer = Prometheus::Client::Formats::OpenMetrics::Writer.new(histogram_without_ts)
+
+        lines = writer.write.split("\n")
+
+        expect(lines).to include("histogram_without_ts_bucket{code=\"ah\",le=\"10\"} 1.0")
+        expect(lines).to include("histogram_without_ts_bucket{code=\"ah\",le=\"20\"} 2.0")
+        expect(lines).to include("histogram_without_ts_bucket{code=\"ah\",le=\"30\"} 2.0")
+        expect(lines).to include("histogram_without_ts_bucket{code=\"ah\",le=\"+Inf\"} 2.0")
+        expect(lines).to include("histogram_without_ts_sum{code=\"ah\"} 15.2")
+        expect(lines).to include("histogram_without_ts_count{code=\"ah\"} 2.0")
+      end
       it "generates a metric with a timestamp"
       it "generates a metric with an exemplar"
     end

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -79,10 +79,8 @@ describe Prometheus::Client::Summary do
       summary.observe(3, labels: { status: 'bar' })
       summary.observe(5, labels: { status: 'foo' })
 
-      expect(summary.values).to eql(
-        { status: 'bar' } => { "count" => 1.0, "sum" => 3.0 },
-        { status: 'foo' } => { "count" => 1.0, "sum" => 5.0 },
-      )
+      expect(summary.values[{ status: 'bar' }].value).to eql({ "count" => 1.0, "sum" => 3.0 })
+      expect(summary.values[{ status: 'foo' }].value).to eql({ "count" => 1.0, "sum" => 5.0 })
     end
   end
 
@@ -96,18 +94,14 @@ describe Prometheus::Client::Summary do
         summary.init_label_set(status: 'bar')
         summary.init_label_set(status: 'foo')
 
-        expect(summary.values).to eql(
-          { status: 'bar' } => { "count" => 0.0, "sum" => 0.0 },
-          { status: 'foo' } => { "count" => 0.0, "sum" => 0.0 },
-        )
+        expect(summary.values[{ status: 'bar' }].value).to eql({ "count" => 0.0, "sum" => 0.0 })
+        expect(summary.values[{ status: 'foo' }].value).to eql({ "count" => 0.0, "sum" => 0.0 })
       end
     end
 
     context "without labels" do
       it 'automatically initializes the metric' do
-        expect(summary.values).to eql(
-          {} => { "count" => 0.0, "sum" => 0.0 },
-        )
+        expect(summary.values[{}].value).to eql({ "count" => 0.0, "sum" => 0.0 })
       end
     end
   end

--- a/spec/prometheus/client/value_with_exemplar_spec.rb
+++ b/spec/prometheus/client/value_with_exemplar_spec.rb
@@ -1,0 +1,52 @@
+# encoding: UTF-8
+
+require 'prometheus/client/exemplar'
+require 'prometheus/client/exemplar_collection'
+
+describe Prometheus::Client::ValueWithExemplars do
+  describe "set" do
+    it "updates the value as a float" do
+      vwe = described_class.new
+
+      vwe.set(value: 5)
+
+      expect(vwe.value).to eq(5.0)
+    end
+
+    it "stores an exemplar and updates its value" do
+      vwe = described_class.new
+
+      exemplar = Prometheus::Client::Exemplar.new(labels: {hotdogs: "great"})
+      vwe.set(value: 5, exemplar: exemplar)
+
+      expect(vwe.most_recent_exemplar.value).to eq(5.0)
+    end
+  end
+
+  describe "increment" do
+    it "updates the value as a float" do
+      vwe = described_class.new
+
+      vwe.set(value: 5)
+      exemplar = Prometheus::Client::Exemplar.new(labels: {hotdogs: "great"})
+      vwe.increment(by: 7, exemplar: exemplar)
+
+      expect(vwe.value).to eq(12.0)
+      expect(vwe.most_recent_exemplar.value).to eq(12.0)
+    end
+  end
+
+  describe "most_recent_exemplar" do
+    it "returns the most recent exemplar by timestamp" do
+      vwe = described_class.new
+
+      vwe.set(value: 5)
+      exemplar = Prometheus::Client::Exemplar.new(labels: {hotdogs: "great"})
+      vwe.increment(by: 7, exemplar: exemplar)
+      vwe.increment(by: 3)
+
+      expect(vwe.value).to eq(15.0)
+      expect(vwe.most_recent_exemplar.value).to eq(12.0)
+    end
+  end
+end

--- a/spec/prometheus/middleware/exporter_spec.rb
+++ b/spec/prometheus/middleware/exporter_spec.rb
@@ -35,7 +35,6 @@ describe Prometheus::Middleware::Exporter do
         registry.counter(:foo, docstring: 'foo counter').increment(by: 9)
 
         get '/metrics', nil, headers
-        # require "pry"; binding.pry
 
         expect(last_response.status).to eql(200)
         expect(last_response.headers['content-type']).to eql(fmt::CONTENT_TYPE)
@@ -45,7 +44,7 @@ describe Prometheus::Middleware::Exporter do
 
     shared_examples 'not acceptable' do |headers|
       it 'responds with 406 Not Acceptable' do
-        message = 'Supported media types: text/plain'
+        message = 'Supported media types: application/openmetrics-text'
 
         get '/metrics', nil, headers
 
@@ -67,27 +66,29 @@ describe Prometheus::Middleware::Exporter do
       include_examples 'not acceptable', 'HTTP_ACCEPT' => 'application/json'
     end
 
-    context 'when client requests text/plain' do
-      include_examples 'ok', { 'HTTP_ACCEPT' => 'text/plain' }, text
-    end
-
-    context 'when client uses different white spaces in Accept header' do
-      accept = 'text/plain;q=1.0  ; version=0.0.1' # why is this version hard coded?
-
-      include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
-    end
-
-    context 'when client does not include quality attribute' do
-      accept = 'application/json;q=0.5, text/plain'
-
-      include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
-    end
-
-    context 'when client accepts some unknown formats' do
-      accept = 'text/plain;q=0.3, proto/buf;q=0.7'
-
-      include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
-    end
+    # the openmetrics type does not accept text plain
+    # not sure if this is good or bad
+    # context 'when client requests text/plain' do
+    #   include_examples 'ok', { 'HTTP_ACCEPT' => 'text/plain' }, text
+    # end
+    #
+    # context 'when client uses different white spaces in Accept header' do
+    #   accept = 'text/plain;q=1.0  ; version=0.0.1' # why is this version hard coded?
+    #
+    #   include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
+    # end
+    #
+    # context 'when client does not include quality attribute' do
+    #   accept = 'application/json;q=0.5, text/plain'
+    #
+    #   include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
+    # end
+    #
+    # context 'when client accepts some unknown formats' do
+    #   accept = 'text/plain;q=0.3, proto/buf;q=0.7'
+    #
+    #   include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
+    # end
 
     context 'when client accepts only unknown formats' do
       accept = 'fancy/woo;q=0.3, proto/buf;q=0.7'

--- a/spec/prometheus/middleware/exporter_spec.rb
+++ b/spec/prometheus/middleware/exporter_spec.rb
@@ -26,13 +26,16 @@ describe Prometheus::Middleware::Exporter do
   end
 
   context 'when requesting /metrics' do
-    text = Prometheus::Client::Formats::Text
+    # I am pretty annoyed at this hard coded format right now
+    # it should match the list of formats in the exporter and loop over the available ones
+    text = Prometheus::Client::Formats::OpenMetrics
 
     shared_examples 'ok' do |headers, fmt|
       it "responds with 200 OK and content-type #{fmt::CONTENT_TYPE}" do
         registry.counter(:foo, docstring: 'foo counter').increment(by: 9)
 
         get '/metrics', nil, headers
+        # require "pry"; binding.pry
 
         expect(last_response.status).to eql(200)
         expect(last_response.headers['content-type']).to eql(fmt::CONTENT_TYPE)
@@ -69,7 +72,7 @@ describe Prometheus::Middleware::Exporter do
     end
 
     context 'when client uses different white spaces in Accept header' do
-      accept = 'text/plain;q=1.0  ; version=0.0.4'
+      accept = 'text/plain;q=1.0  ; version=0.0.1' # why is this version hard coded?
 
       include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
     end


### PR DESCRIPTION
Hackish implementation of
- Openmetrics text/wire format for a few of the metric types
- Exemplar setting, storage, and generation (extremely hackish)
- Updated interface to data stores (tests not yet updated)
- Most of the open metrics text format missing features represented as unwritten tests
- Not sure what to do with timestamps or multiple exemplar generation so I punted